### PR TITLE
fix(runtime): Add size validation to IOBufferTracker.pop

### DIFF
--- a/pyv_npu/runtime/resources.py
+++ b/pyv_npu/runtime/resources.py
@@ -41,8 +41,9 @@ class IOBufferTracker:
         # Find the tensor in the deque and remove it.
         for i, (size, name) in enumerate(self.queue):
             if name == tensor_name:
-                # In a stricter model, we might also validate 'num_bytes' against 'size'.
-                # For now, trust the scheduler to provide the correct size.
+                # Validate that the size provided by the scheduler matches the stored size.
+                if num_bytes != size:
+                    raise ValueError(f"[{self.name}] Size mismatch for tensor {tensor_name}. Expected {size}, got {num_bytes}.")
                 self.current_fill_bytes -= size
                 del self.queue[i]
                 return

--- a/tests/runtime/test_io_buffer.py
+++ b/tests/runtime/test_io_buffer.py
@@ -86,3 +86,9 @@ def test_pop_non_existent(io_buffer):
     io_buffer.push(100, "tensor_a")
     with pytest.raises(ValueError, match="not in buffer for popping"):
         io_buffer.pop(100, "tensor_b")
+
+def test_pop_size_mismatch(io_buffer):
+    """Tests that popping a tensor with an incorrect size raises a ValueError."""
+    io_buffer.push(100, "tensor_a")
+    with pytest.raises(ValueError, match="Size mismatch for tensor tensor_a"):
+        io_buffer.pop(99, "tensor_a")


### PR DESCRIPTION
- Adds a validation check to ensure the byte size provided by the scheduler matches the stored size of the tensor being popped.
- This addresses the code review suggestion from PR #26 to prevent potential silent bugs.
- Adds a unit test to verify the new validation logic.