### PR TITLE
feat(memory): Parameterize DRAM address mapping

### DIFF
--- a/docs/planning/working_history.md
+++ b/docs/planning/working_history.md
@@ -1,3 +1,7 @@
+V250909b - M-01: DRAM 정책 파라미터화 적용 (feature/m-01-dram-policy-parameterization):
+  - DramAddressMapper가 하드코딩된 페이지 크기 대신 SimConfig의 `dram_page_size`를 사용하도록 수정.
+  - `dram_mapping_policy` 설정을 존중하도록 매핑 로직을 수정하고, 관련 단위 테스트를 수정하여 안정성 확보.
+
 V250909a - M-01: 메모리 모델 파라미터화 (feature/m-01-memory-model-enhancement-v2):
   - `SimConfig`에 `spm_bank_ports`와 `dma_burst_size` 파라미터를 추가.
   - `BankTracker`가 SPM 포트 경합을 모델링하도록 수정하고, `BandwidthTracker`가 DMA 버스트 크기를 고려하도록 수정.

--- a/pyv_npu/runtime/memory.py
+++ b/pyv_npu/runtime/memory.py
@@ -8,22 +8,30 @@ class DramAddressMapper:
         self.policy = config.dram_mapping_policy
         self.channels = config.dram_channels
         self.banks_per_channel = config.dram_banks_per_channel
-        # Use page size from config instead of hardcoded value
+        
+        # 1. Validate config parameter
         self.row_size = config.dram_page_size
+        if self.row_size <= 0:
+            raise ValueError("DRAM page size (row_size) must be a positive integer.")
+
+        # 2. Refactor to a dispatch dictionary for extensibility
+        self._map_policies = {
+            "interleave": self._map_interleave,
+        }
+        if self.policy not in self._map_policies:
+            raise ValueError(f"Unknown or unsupported DRAM mapping policy: {self.policy}")
+        self._map_func = self._map_policies[self.policy]
 
     def map(self, address: int) -> tuple[int, int]:
-        """
-        Maps a physical address to (channel_id, bank_id).
-        Supports different mapping policies based on config.
-        """
-        if self.policy == "interleave":
-            # A simple policy: interleave channels based on low-order bits of the row number
-            row_number = address // self.row_size
-            channel_id = row_number % self.channels
-            
-            # Interleave banks based on the next bits
-            bank_id = (row_number // self.channels) % self.banks_per_channel
-            
-            return channel_id, bank_id
-        else:
-            raise ValueError(f"Unknown or unsupported DRAM mapping policy: {self.policy}")
+        """Maps a physical address to (channel_id, bank_id) using the configured policy."""
+        return self._map_func(address)
+
+    def _map_interleave(self, address: int) -> tuple[int, int]:
+        """A simple policy: interleave channels based on low-order bits of the row number."""
+        row_number = address // self.row_size
+        channel_id = row_number % self.channels
+        
+        # Interleave banks based on the next bits
+        bank_id = (row_number // self.channels) % self.banks_per_channel
+        
+        return channel_id, bank_id

--- a/pyv_npu/runtime/memory.py
+++ b/pyv_npu/runtime/memory.py
@@ -8,20 +8,22 @@ class DramAddressMapper:
         self.policy = config.dram_mapping_policy
         self.channels = config.dram_channels
         self.banks_per_channel = config.dram_banks_per_channel
-        # Assuming row size is the most significant interleaving factor
-        # and it's larger than a typical cache line. Let's use a fixed value for now.
-        self.row_size = 2048 
+        # Use page size from config instead of hardcoded value
+        self.row_size = config.dram_page_size
 
     def map(self, address: int) -> tuple[int, int]:
         """
         Maps a physical address to (channel_id, bank_id).
-        A simple interleaving policy based on row address.
+        Supports different mapping policies based on config.
         """
-        # A simple policy: interleave channels based on low-order bits of the row number
-        row_number = address // self.row_size
-        channel_id = row_number % self.channels
-        
-        # Interleave banks based on the next bits
-        bank_id = (row_number // self.channels) % self.banks_per_channel
-        
-        return channel_id, bank_id
+        if self.policy == "interleave":
+            # A simple policy: interleave channels based on low-order bits of the row number
+            row_number = address // self.row_size
+            channel_id = row_number % self.channels
+            
+            # Interleave banks based on the next bits
+            bank_id = (row_number // self.channels) % self.banks_per_channel
+            
+            return channel_id, bank_id
+        else:
+            raise ValueError(f"Unknown or unsupported DRAM mapping policy: {self.policy}")

--- a/tests/runtime/test_memory.py
+++ b/tests/runtime/test_memory.py
@@ -7,10 +7,9 @@ def test_dram_address_mapper_interleave():
     config = SimConfig(
         dram_channels=4,
         dram_banks_per_channel=8,
-        dram_mapping_policy="interleave"
+        dram_mapping_policy="interleave",
+        dram_page_size=2048  # Explicitly set for this test
     )
-    # In the current implementation, row_size is fixed at 2048
-    row_size = 2048
     
     mapper = DramAddressMapper(config)
 

--- a/tests/test_dram_policy_comparison.py
+++ b/tests/test_dram_policy_comparison.py
@@ -30,7 +30,13 @@ def test_dram_policy_collision_comparison():
 
     # --- Run with settings designed to avoid collisions ---
     # Use multiple channels. Addresses are chosen to map to different channels.
-    config_no_collide = SimConfig(sim_level='CA_HYBRID', dram_channels=2, dram_banks_per_channel=2, dram_mapping_policy='interleave')
+    config_no_collide = SimConfig(
+        sim_level='CA_HYBRID',
+        dram_channels=2,
+        dram_banks_per_channel=2,
+        dram_mapping_policy='interleave',
+        dram_page_size=2048  # Set page size so addr 2048 maps to a new channel
+    )
     # addr1 (0) maps to channel 0. addr2 (2048) maps to channel 1.
     prog_no_collide = create_program_with_parallel_loads(addr1=0, addr2=2048)
     schedule_no_collide, stats_no_collide = run_sim(prog_no_collide, config_no_collide)


### PR DESCRIPTION
- Update DramAddressMapper to use dram_page_size from SimConfig instead of a hardcoded row size.
- Implement policy-based dispatch in the mapper to support different DRAM address mapping schemes, starting with the existing 'interleave' policy.
- Fix unit tests for the DRAM mapper and policy comparisons that failed due to the corrected page size handling, making them robust to config changes.