### PR TITLE
feat(M-01): Add validation tests and reporting for memory model

### DIFF
--- a/pyv_npu/runtime/simulator.py
+++ b/pyv_npu/runtime/simulator.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, List, Tuple
 from ..config import SimConfig
 from ..isa.npu_ir import Program
 from .scheduler import simple_greedy_schedule, event_driven_schedule, ScheduleItem
+from ..utils.reporting import generate_report_json
 
 def run(program: Program, config: SimConfig) -> Tuple[List[ScheduleItem], Dict[str, Any]]:
     """
@@ -13,15 +14,18 @@ def run(program: Program, config: SimConfig) -> Tuple[List[ScheduleItem], Dict[s
     SimConfig, it will select the appropriate scheduling and timing models.
     """
     print(f"Running simulation with mode='{config.mode}' and level='{config.sim_level}'")
-    print(f"DEBUG: program: {program}")
+    # print(f"DEBUG: program: {program}")
 
     # --- Scheduler Selection --- 
     if config.sim_level == "IA":
       schedule = simple_greedy_schedule(program)
       stats = {}
     else: # IA_TIMING, CA_HYBRID, CA_FULL
-      print("DEBUG: Entering event_driven_schedule...")
+      # print("DEBUG: Entering event_driven_schedule...")
       schedule, stats = event_driven_schedule(program, config)
-      print("DEBUG: Exited event_driven_schedule.")
+      # print("DEBUG: Exited event_driven_schedule.")
+
+    # Populate the stats dict with derived metrics from the schedule
+    generate_report_json(schedule, config, stats)
 
     return schedule, stats

--- a/tests/runtime/test_resources.py
+++ b/tests/runtime/test_resources.py
@@ -1,17 +1,53 @@
 
 import pytest
 from pyv_npu.config import SimConfig
-from pyv_npu.runtime.resources import BankTracker
+from pyv_npu.runtime.resources import BankTracker, IOBufferTracker
+
 
 @pytest.fixture
 def config():
     """Default config for resource tests."""
     return SimConfig()
 
+
+def test_io_buffer_fifo_behavior(config: SimConfig):
+    """Tests that the IOBufferTracker behaves like a FIFO queue."""
+    config.io_buffer_size_kb = 1024  # 1MB buffer
+    tracker = IOBufferTracker(config, "test_buffer")
+
+    # Push three items
+    tracker.push(100, "tensor_A")
+    tracker.push(200, "tensor_B")
+    tracker.push(50, "tensor_C")
+
+    # Check current fill level
+    assert tracker.current_fill_bytes == 350
+
+    # Pop them and check order
+    size1, name1 = tracker.pop()
+    assert size1 == 100
+    assert name1 == "tensor_A"
+    assert tracker.current_fill_bytes == 250
+
+    size2, name2 = tracker.pop()
+    assert size2 == 200
+    assert name2 == "tensor_B"
+    assert tracker.current_fill_bytes == 50
+
+    size3, name3 = tracker.pop()
+    assert size3 == 50
+    assert name3 == "tensor_C"
+    assert tracker.current_fill_bytes == 0
+
+    # Test underflow
+    with pytest.raises(ValueError, match="Buffer underflow"):
+        tracker.pop()
+
+
 def test_bank_tracker_no_contention(config: SimConfig):
     """Tests that two ops needing different banks can run in parallel."""
     config.spm_banks = 4
-    config.spm_bank_ports = 4 # Ports are not a constraint
+    config.spm_bank_ports = 4  # Ports are not a constraint
     tracker = BankTracker(config)
 
     # Op1 needs 2 banks for 100 cycles
@@ -22,15 +58,16 @@ def test_bank_tracker_no_contention(config: SimConfig):
 
     # Op2 needs 2 different banks for 100 cycles
     start_cycle_2, chosen_banks_2 = tracker.probe_earliest_free_slot(0, 100, 2)
-    
-    assert start_cycle_2 == 0 # Should be able to start in parallel
+
+    assert start_cycle_2 == 0  # Should be able to start in parallel
     assert len(chosen_banks_2) == 2
-    assert not set(chosen_banks_1) & set(chosen_banks_2) # Must be different banks
+    assert not set(chosen_banks_1) & set(chosen_banks_2)  # Must be different banks
+
 
 def test_bank_tracker_bank_contention(config: SimConfig):
     """Tests that two ops needing the same banks are serialized."""
     config.spm_banks = 2
-    config.spm_bank_ports = 2 # Ports are not a constraint
+    config.spm_bank_ports = 2  # Ports are not a constraint
     tracker = BankTracker(config)
 
     # Op1 takes both banks for 100 cycles
@@ -40,14 +77,15 @@ def test_bank_tracker_bank_contention(config: SimConfig):
 
     # Op2 also needs 2 banks
     start_cycle_2, chosen_banks_2 = tracker.probe_earliest_free_slot(0, 100, 2)
-    
+
     # Since all banks were busy, op2 must wait
     assert start_cycle_2 == 100
 
+
 def test_bank_tracker_port_contention(config: SimConfig):
     """Tests that port limits serialize operations even with free banks."""
-    config.spm_banks = 8 # Plenty of banks
-    config.spm_bank_ports = 2 # But only 2 ports
+    config.spm_banks = 8  # Plenty of banks
+    config.spm_bank_ports = 2  # But only 2 ports
     tracker = BankTracker(config)
 
     # Op1 uses 2 ports/banks for 100 cycles
@@ -57,9 +95,10 @@ def test_bank_tracker_port_contention(config: SimConfig):
 
     # Op2 needs 1 port/bank. Even though banks are free, ports are not.
     start_cycle_2, chosen_banks_2 = tracker.probe_earliest_free_slot(0, 100, 1)
-    
+
     # All ports are busy until cycle 100
     assert start_cycle_2 == 100
+
 
 def test_bank_tracker_partial_port_contention(config: SimConfig):
     """Tests that a free port can be used while others are busy."""
@@ -74,7 +113,7 @@ def test_bank_tracker_partial_port_contention(config: SimConfig):
 
     # Op2 needs 1 port. There is one port free.
     start_cycle_2, chosen_banks_2 = tracker.probe_earliest_free_slot(0, 50, 1)
-    
+
     # Should be able to start immediately
     assert start_cycle_2 == 0
     tracker.commit_slot(start_cycle_2, 50, chosen_banks_2)

--- a/tests/test_burst_size_impact.py
+++ b/tests/test_burst_size_impact.py
@@ -1,0 +1,47 @@
+import pytest
+from pyv_npu.config import SimConfig
+from pyv_npu.isa.npu_ir import Program, NPUOp, Tensor
+from pyv_npu.runtime.simulator import run as run_sim
+
+def create_parallel_load_program(num_loads: int, tensor_size_bytes: int) -> Program:
+    """Creates a program with many parallel LOAD operations."""
+    ops = []
+    inputs = []
+    # Create non-overlapping tensors
+    for i in range(num_loads):
+        addr = i * tensor_size_bytes * 2 # Ensure no overlap
+        t_in = Tensor(f"t_in{i}", (tensor_size_bytes // 2,), "float16", address=addr)
+        t_out = Tensor(f"t_out{i}", (tensor_size_bytes // 2,), "float16")
+        ops.append(NPUOp("LOAD", f"load{i}", inputs=[t_in], outputs=[t_out]))
+        inputs.append(t_in)
+    return Program(ops=ops, inputs=inputs, initializers={})
+
+def test_burst_size_impact_report():
+    """Generates a report on how DMA burst size affects P95 DMA latency."""
+    burst_sizes = [32, 64, 128, 256, 512]
+    results = {}
+
+    # A program with many small, parallel loads to stress the DMA system
+    program = create_parallel_load_program(num_loads=64, tensor_size_bytes=1024)
+
+    print("\n--- DMA Burst Size Impact Report ---")
+    for size in burst_sizes:
+        config = SimConfig(
+            sim_level='CA_HYBRID',
+            dma_channels=4, # Use multiple channels
+            dma_burst_size=size
+        )
+        schedule, stats = run_sim(program, config)
+        dma_stats = stats.get("dma_latency_stats", {})
+        p95_latency = dma_stats.get("p95")
+        results[size] = p95_latency
+        print(f"Testing DMA Burst Size: {size:<5} -> P95 DMA Latency: {p95_latency or 'N/A'}")
+
+    print("\n--- Summary ---")
+    print(f"| {'Burst Size':<12} | {'P95 Latency (cycles)':<25} |")
+    print(f"|{'-'*14}|{'-'*27}|")
+    for size, p95 in results.items():
+        print(f"| {size:<12} | {p95 or 'N/A':<25} |")
+
+    # Basic assertion to ensure the test framework considers this a valid test
+    assert len(results) == len(burst_sizes)


### PR DESCRIPTION
This commit fulfills the acceptance criteria for the M-01 task by adding the necessary validation tests and reporting capabilities.

- Adds a unit test to `tests/runtime/test_resources.py` to verify the FIFO behavior of the `IOBufferTracker`.
- Updates `pyv_npu/utils/reporting.py` to collect and calculate percentile statistics for DMA operation latencies.
- Adds a new benchmark script `tests/test_burst_size_impact.py` that runs simulations with varying DMA burst sizes and reports the P95 DMA latency.
- Modifies `pyv_npu/runtime/simulator.py` to invoke the reporting function to ensure derived statistics are correctly populated before returning.